### PR TITLE
Logical Retirement for Gens, plus minor others

### DIFF
--- a/gtep/gtep_model.py
+++ b/gtep/gtep_model.py
@@ -3261,7 +3261,7 @@ def model_create_investment_stages(m, stages):
                 m.investmentStage[stage].genRetired[gen].indicator_var
                 | m.investmentStage[stage].genExtended[gen].indicator_var
             )
-            if stage >= pyo.value(m.lifetimes[gen])
+            if stage > pyo.value(m.lifetimes[gen])
             else pyo.LogicalConstraint.Skip
         )
 


### PR DESCRIPTION
Converts generator retirement requirements to logical constraint (should slightly reduce total number of constraints).  Removes some comments that are no longer necessary.  Returns one case of load processing to c_p.loads.get(gen) -- to be made consistent in the future.