### PR TITLE
Relative path to save data processing csv file

### DIFF
--- a/gtep/gtep_data_processing.py
+++ b/gtep/gtep_data_processing.py
@@ -19,6 +19,9 @@
 import pandas as pd
 from pathlib import Path
 from gtep.config_data import ConfigData
+from os.path import join, dirname, abspath
+
+datadir = join(dirname(abspath(str(__file__))), "data")
 
 """
 References
@@ -292,6 +295,6 @@ class DataProcessing:
         self.gen_data_target.head()
 
         if save_csv:
-            self.gen_data_target.to_csv(
-                "data/costs/candidate_generators_initial_list.csv", index=False
+            filename = join(datadir, "costs", "candidate_generators_initial_list.csv")
+            self.gen_data_target.to_csv(filename, index=False
             )

--- a/gtep/gtep_data_processing.py
+++ b/gtep/gtep_data_processing.py
@@ -296,5 +296,4 @@ class DataProcessing:
 
         if save_csv:
             filename = join(datadir, "costs", "candidate_generators_initial_list.csv")
-            self.gen_data_target.to_csv(filename, index=False
-            )
+            self.gen_data_target.to_csv(filename, index=False)


### PR DESCRIPTION
Minor update to use relative path to save csv file, useful when the driver file is outside the gtep folder