### PR TITLE
FIX: Regression in testing suite

### DIFF
--- a/.github/workflows/release_wheel_creation.yml
+++ b/.github/workflows/release_wheel_creation.yml
@@ -28,9 +28,9 @@ jobs:
       matrix:
         python-version: ['3.12']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
         run: |
           python -m build --wheel --outdir dist
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: purepythonwheel
           path: dist/*.whl
@@ -59,9 +59,9 @@ jobs:
           TARGET: generic_tarball
         python-version: ['3.12']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -72,7 +72,7 @@ jobs:
       run: |
         python -m build --sdist --outdir dist
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: generictarball
         path: dist

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -16,8 +16,7 @@ concurrency:
 
 defaults:
   run:
-    # -l: login shell, needed when using Conda run:
-    shell: bash -l {0}
+    shell: bash {0}
 
 jobs:
   code-formatting:

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -58,10 +58,10 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
       
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
 
       - name: Install idaes-gtep
         run: |

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -58,29 +58,15 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
       
-      - name: Set up Miniconda Python
-        uses: conda-incubator/setup-miniconda@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python }}
-          conda-remove-defaults: true
-          auto-update-conda: false
-          channels: conda-forge
-
-      - name: Install Python packages (conda)
-        run: |
-          # Set up environment
-          conda config --set always_yes yes
-          
-          echo "Install Python packages"
-          # Install dependencies needed for testing
-          conda install --yes --quiet pytest highspy 
-          
-          echo "Final conda environment:"
-          conda list | sed 's/^/    /'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install idaes-gtep
         run: |
           pip install -e .
+          pip install pytest highspy
           
       - name: Run Tests
         run: |

--- a/.github/workflows/test_branches.yml
+++ b/.github/workflows/test_branches.yml
@@ -25,8 +25,8 @@ jobs:
     # OS and/or Python version don't make a difference, so we choose ubuntu and 3.10 for performance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install Black
@@ -40,7 +40,7 @@ jobs:
     name: Check Spelling
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run Spell Checker
         uses: crate-ci/typos@master
         with: 
@@ -56,10 +56,10 @@ jobs:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Set up Miniconda Python
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python }}
           conda-remove-defaults: true

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -33,8 +33,8 @@ jobs:
     # OS and/or Python version don't make a difference, so we choose ubuntu and 3.10 for performance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install Black
@@ -48,7 +48,7 @@ jobs:
     name: Check Spelling
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run Spell Checker
         uses: crate-ci/typos@master
         with: 
@@ -65,10 +65,10 @@ jobs:
         python: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Miniconda Python
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python }}
           conda-remove-defaults: true

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -67,29 +67,15 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
 
-      - name: Set up Miniconda Python
-        uses: conda-incubator/setup-miniconda@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python }}
-          conda-remove-defaults: true
-          auto-update-conda: false
-          channels: conda-forge
-
-      - name: Install Python packages (conda)
-        run: |
-          # Set up environment
-          conda config --set always_yes yes
-          
-          echo "Install Python packages"
-          # Install dependencies needed for testing
-          conda install --yes --quiet pytest highspy
-          
-          echo "Final conda environment:"
-          conda list | sed 's/^/    /'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install idaes-gtep
         run: |
           pip install -e .
+          pip install pytest highspy
           
       - name: Run Tests
         run: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -67,10 +67,10 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
 
       - name: Install idaes-gtep
         run: |

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -24,8 +24,7 @@ concurrency:
 
 defaults:
   run:
-    # -l: login shell, needed when using Conda run:
-    shell: bash -l {0}
+    shell: bash {0}
 
 jobs:
   code-formatting:


### PR DESCRIPTION
For some unknown reason, `pip` was no longer being installed through `miniconda` on Mac by default. The quickest fix would have been to just add that to the conda install step, but conda really wasn't necessary. So instead, this removes conda as a consideration at all and just relies on `setup-python`.

Also, several action versions were out of date, so I updated those while I was there.