### PR TITLE
Fix loads

### DIFF
--- a/gtep/model_library/components.py
+++ b/gtep/model_library/components.py
@@ -499,13 +499,13 @@ def add_model_parameters(m, num_commit, num_dispatch, duration_dispatch):
     # Initialize curtailment and load shed costs as parameters and
     # re-calculate them during the investment stage.
     m.curtailmentCost = pyo.Param(
-        initialize=1,
+        initialize=0,
         units=u.USD / (u.MW * u.hr),
         mutable=True,
         doc="Curtailment cost",
     )
     m.loadShedCostperCurtailment = pyo.Param(
-        initialize=1000,
+        initialize=30000,
         units=u.USD / (u.MW * u.hr),
         mutable=True,
     )
@@ -650,7 +650,3 @@ def add_model_cost_parameters(m, year):
     # Cost per MW of curtailed renewable energy. This equation
     # re-calculates curtailment and load shed costa since they depend
     # on the re-defined parameter "fuelCost".
-    m.curtailmentCost = 2 * max(
-        pyo.value(m.fuelCost[gen]) for gen in m.thermalGenerators
-    )
-    m.loadShedCostperCurtailment = 1000 * m.curtailmentCost

--- a/gtep/model_library/dispatch.py
+++ b/gtep/model_library/dispatch.py
@@ -239,7 +239,7 @@ def add_dispatch_constraints(b, disp_per):
             balance += sum(b.storageDischarged[bt] for bt in batts)
             balance -= sum(b.storageCharged[bt] for bt in batts)
 
-            balance -= sum(m.loads[l] for l in loads)
+            balance -= sum(c_p.loads[l] for l in loads)
             balance += sum(b.loadShed[bus] for bus in buses)
 
             return balance == 0
@@ -282,7 +282,7 @@ def add_dispatch_constraints(b, disp_per):
             balance -= sum(b.storageCharged[bt] for bt in batts)
 
             # Add the loads as a parameter (already includes units).
-            balance -= m.loads[bus]
+            balance -= c_p.loads[bus]
             balance += b.loadShed[bus]
             return balance == 0 * u.MW
 

--- a/gtep/model_library/scaling.py
+++ b/gtep/model_library/scaling.py
@@ -16,20 +16,18 @@ Model
 
 """
 
+import pyomo.environ as pyo
+from pyomo.environ import units as u
 
 def add_load_scaling(m, b, commitment_period, investment_stage, scaling_value):
 
-    # Create a false load directory. [TODO: Commented for now since it
-    # is not used. Check with team if we want to preserve this for
-    # Texas case.]
-    # false_loads = []
-    # for load in m.md.data["elements"]["load"]:
-    #     if type(m.md.data["elements"]["load"][load]) == float:
-    #         false_loads.append(load)
-    # for load in false_loads:
-    #     del m.md.data["elements"]["load"][load]
-    #     # del m.loads[load]
-    # # print(m.loads)
+    b.loads = pyo.Param(
+        m.buses,
+        initialize={load_n: 0 for load_n in m.buses},
+        mutable=True,
+        units=u.MW,
+        doc="Demand at each bus",
+    )
 
     # Loop over the demand at each bus and scale based on the case.
     for load_n in m.load_buses:
@@ -39,20 +37,20 @@ def add_load_scaling(m, b, commitment_period, investment_stage, scaling_value):
 
         if m.config["scale_loads"]:
             temp_scale = 10
-            m.loads[load_n] = (
+            b.loads[load_n] = (
                 p_load
                 * temp_scale
                 * (1 + (temp_scale + investment_stage) / (temp_scale + len(m.stages)))
             )
 
         elif m.config["scale_texas_loads"]:
-            m.loads[load_n] = (
+            b.loads[load_n] = (
                 p_load
                 * b.load_scaling[m.md.data["elements"]["load"][load_n]["zone"]].iloc[0]
             )
 
         else:
-            m.loads[load_n] = p_load
+            b.loads[load_n] = p_load
 
         # for key, val in b.loads.items():
         #     # print(f"{key=}")

--- a/gtep/model_library/scaling.py
+++ b/gtep/model_library/scaling.py
@@ -19,6 +19,7 @@ Model
 import pyomo.environ as pyo
 from pyomo.environ import units as u
 
+
 def add_load_scaling(m, b, commitment_period, investment_stage, scaling_value):
 
     b.loads = pyo.Param(

--- a/gtep/tests/unit/test_gtep_model.py
+++ b/gtep/tests/unit/test_gtep_model.py
@@ -407,7 +407,7 @@ class TestGTEP(unittest.TestCase):
         modObject.results = opt.solve(modObject.model)
 
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 779334165.7, places=1
+            value(modObject.model.total_cost_objective_rule), 926190541.3, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)

--- a/gtep/tests/unit/test_gtep_model.py
+++ b/gtep/tests/unit/test_gtep_model.py
@@ -275,9 +275,9 @@ class TestGTEP(unittest.TestCase):
 
         modObject.results = opt.solve(modObject.model)
 
-        # previous successful objective values: 9207.95, 6078.86, 531860.15, 531883.43
+        # previous successful objective values: 9207.95, 6078.86, 531860.15, 531883.43, 7977055.4
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 531883.43, places=1
+            value(modObject.model.total_cost_objective_rule), 7977055.4, places=1
         )
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
 
@@ -310,9 +310,9 @@ class TestGTEP(unittest.TestCase):
 
         modObject.results = opt.solve(modObject.model)
 
-        # previous successful objective values: 531860.15, 531883.43
+        # previous successful objective values: 531860.15, 531883.43, 7977055.4
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 531883.43, places=1
+            value(modObject.model.total_cost_objective_rule), 7977055.4, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
@@ -358,9 +358,9 @@ class TestGTEP(unittest.TestCase):
 
         modObject.results = opt.solve(modObject.model)
 
-        # previous successful objective values: 1524581869.89
+        # previous successful objective values: 1524581869.89, 779334165.7
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 1524533561.02, places=1
+            value(modObject.model.total_cost_objective_rule), 779334165.7, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
@@ -407,7 +407,7 @@ class TestGTEP(unittest.TestCase):
         modObject.results = opt.solve(modObject.model)
 
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 1524533561.02, places=1
+            value(modObject.model.total_cost_objective_rule), 779334165.7, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)


### PR DESCRIPTION
Repeatedly updating m.loads results in only matching the final load period for all possible dispatch periods.

New version has loads per commitment block; will have to update this to have dispatch level load scaling.