### PR TITLE
Fix costs dict key and num_reps in driver_coal

### DIFF
--- a/gtep/driver_coal.py
+++ b/gtep/driver_coal.py
@@ -48,7 +48,7 @@ data_object.texas_case_study_updates(data_path)
 # 4 representative days (1 per season)
 # Hourly commitment and dispatch
 mod_object = ExpansionPlanningModel(
-    stages=3, data=data_object, num_reps=5, len_reps=24, num_commit=24, num_dispatch=1
+    stages=3, data=data_object, num_reps=4, len_reps=24, num_commit=24, num_dispatch=1
 )
 # print(mod_object.data.data["elements"]["generator"]["1"])
 # import sys
@@ -128,9 +128,9 @@ for var in mod_object.model.component_objects(gdp.Disjunct, descend_into=True):
 costs = {}
 for exp in mod_object.model.component_objects(pyo.Expression, descend_into=True):
     if "operatingCost" in exp.name:
-        costs[var.name] = pyo.value(exp)
+        costs[exp.name] = pyo.value(exp)
     elif "investmentCost" in exp.name:
-        costs[var.name] = pyo.value(exp)
+        costs[exp.name] = pyo.value(exp)
 
 import json
 


### PR DESCRIPTION
Two small fixes in driver_coal.py:

- costs extraction used `var.name` instead of `exp.name` when iterating Expression objects, causing all entries to map to the last Disjunct variable name
- `num_reps` was 5, should be 4 to match the 4 seasonal representative periods