### PR TITLE
Guard storage access in CP_flow_balance

### DIFF
--- a/gtep/model_library/dispatch.py
+++ b/gtep/model_library/dispatch.py
@@ -228,7 +228,7 @@ def add_dispatch_constraints(b, disp_per):
             buses = [bus for bus in m.buses]
             loads = [l for l in b.loads]
             gens = [gen for gen in m.generators]
-            batts = [bat for bat in m.storage]
+            batts = [bat for bat in m.storage] if m.config["storage"] else []
             balance += sum(
                 b.thermalGeneration[g] for g in gens if g in m.thermalGenerators
             )


### PR DESCRIPTION
CP_flow_balance unconditionally iterates m.storage, but m.storage is only created when storage data exists. The non-CP flow_balance path already guards with m.config["storage"]; this makes the CP path consistent.