### PR TITLE
Add non_fuel_startup_cost default in data loading

### DIFF
--- a/gtep/gtep_data.py
+++ b/gtep/gtep_data.py
@@ -330,6 +330,9 @@ class ExpansionPlanningData:
                     self.md.data["elements"]["generator"][gen]["emissions_factor"] = 1
                     self.md.data["elements"]["generator"][gen]["start_fuel"] = 1
                     self.md.data["elements"]["generator"][gen]["investment_cost"] = 1
+                    self.md.data["elements"]["generator"][gen].setdefault(
+                        "non_fuel_startup_cost", 0
+                    )
             if "branch" in self.md.data["elements"].keys():
                 for branch in self.md.data["elements"]["branch"]:
                     self.md.data["elements"]["branch"][branch]["loss_rate"] = 0


### PR DESCRIPTION
Generators that lack non_fuel_startup_cost in input data cause a KeyError when components.py initializes startupCost. This adds a setdefault fallback of 0 in load_default_data_settings, consistent with how other generator fields are defaulted in the same block.