### PR TITLE
Thermal generation fixes

### DIFF
--- a/gtep/model_library/components.py
+++ b/gtep/model_library/components.py
@@ -406,6 +406,15 @@ def add_model_parameters(m, num_commit, num_dispatch, duration_dispatch):
         doc="Cost per unit of fuel at each generator",
     )
 
+    # setting to be the same as real fuel cost for now... but maybe should be different?
+    m.fuelCostReactive = pyo.Param(
+        m.generators,
+        initialize={gen: m.fuelCost[gen] for gen in m.thermalGenerators},
+        mutable=True,
+        units=u.USD / (u.MVAR * u.hr),
+        doc="Cost per unit of fuel at each generator (reactive power)",
+    )
+
     m.emissionsFactor = pyo.Param(
         m.generators,
         initialize={
@@ -684,6 +693,7 @@ def add_model_cost_parameters(m, year):
     units_var_cost = u.USD / (u.MW * u.hr)
     units_inv_cost = u.USD / u.kW
     units_fuel_cost = u.USD / (u.MW * u.hr)
+    units_reactive_fuel_cost = u.USD / (u.MVAR * u.hr)
     for gen in m.generators:
         if m.md.data["elements"]["generator"][gen]["generator_type"] == "thermal":
             m.fixedCost[gen] = pyo.units.convert(
@@ -699,7 +709,7 @@ def add_model_cost_parameters(m, year):
             # Add fuel costs from preprocessed data. Consider this
             # cost is for Natural Gas generators, not coal.
             m.fuelCost[gen] = m.genThermalFuelCost[0] * units_fuel_cost
-
+            m.fuelCostReactive[gen] = m.genThermalFuelCost[0] * units_reactive_fuel_cost
         else:
 
             # For renewable

--- a/gtep/model_library/components.py
+++ b/gtep/model_library/components.py
@@ -177,6 +177,28 @@ def add_model_parameters(m, num_commit, num_dispatch, duration_dispatch):
         doc="Maximum output of each thermal generator",
     )
 
+    m.thermalReactiveMax = pyo.Param(
+        m.thermalGenerators,
+        initialize={
+            thermalGen: m.md.data["elements"]["generator"][thermalGen]["q_max"]
+            for thermalGen in m.thermalGenerators
+        },
+        mutable=True,
+        units=u.MVAR,
+        doc="Maximum reactive output of each thermal generator",
+    )
+
+    m.thermalReactiveMin = pyo.Param(
+        m.thermalGenerators,
+        initialize={
+            thermalGen: m.md.data["elements"]["generator"][thermalGen]["q_min"]
+            for thermalGen in m.thermalGenerators
+        },
+        mutable=True,
+        units=u.MVAR,
+        doc="Minimum reactive output of each thermal generator",
+    )
+
     m.lifetimes = pyo.Param(
         m.generators,
         initialize={

--- a/gtep/model_library/dispatch.py
+++ b/gtep/model_library/dispatch.py
@@ -77,7 +77,11 @@ def add_dispatch_variables(b, dispatch_period, paramPeriodLength):
 
         @b.Expression(m.thermalGenerators, doc="Reactive power cost per generator")
         def reactiveGeneratorCost(b, gen):
-            return b.thermalReactiveGeneration[gen] * m.fuelCost[gen]
+            return (
+                b.thermalReactiveGeneration[gen]
+                * u.convert(m.dispatchPeriodLength, to_units=u.hr)
+                * m.fuelCostReactive[gen]
+            )
 
     b.loadShed = pyo.Var(
         m.buses,

--- a/gtep/model_library/dispatch.py
+++ b/gtep/model_library/dispatch.py
@@ -62,7 +62,7 @@ def add_dispatch_variables(b, dispatch_period, paramPeriodLength):
         return (
             b.thermalGeneration[gen]
             * pyo.units.convert(paramPeriodLength, to_units=u.hr)
-            * (m.fixedCost[gen] + m.varCost[gen])
+            * (m.fixedCost[gen] + m.varCost[gen] + m.fuelCost[gen])
         )
 
     @b.Expression(m.renewableGenerators, doc="Cost per renewable generator in $")

--- a/gtep/model_library/gen.py
+++ b/gtep/model_library/gen.py
@@ -768,7 +768,7 @@ def add_dispatch_generators_variables(m, b):
         def thermal_reactive_generation_limits(
             b, thermalGen, doc="Bounds on thermal generator reactive generation"
         ):
-            return (0, m.thermalReactiveCapacity[thermalGen])
+            return (m.thermalReactiveMin[thermalGen], m.thermalReactiveMax[thermalGen])
 
         b.thermalReactiveGeneration = pyo.Var(
             m.thermalGenerators,

--- a/gtep/tests/unit/test_gtep_model.py
+++ b/gtep/tests/unit/test_gtep_model.py
@@ -282,9 +282,9 @@ class TestGTEP(unittest.TestCase):
 
         modObject.results = opt.solve(modObject.model)
 
-        # previous successful objective values: 9207.95, 6078.86, 531860.15, 531883.43, 7977055.4
+        # previous successful objective values: 9207.95, 6078.86, 531860.15, 531883.43, 7977055.4, 7977055.4
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 7977055.4, places=1
+            value(modObject.model.total_cost_objective_rule), 7977107.43, places=1
         )
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
 
@@ -317,9 +317,9 @@ class TestGTEP(unittest.TestCase):
 
         modObject.results = opt.solve(modObject.model)
 
-        # previous successful objective values: 531860.15, 531883.43, 7977055.4
+        # previous successful objective values: 531860.15, 531883.43, 7977055.4, 7977055.4
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 7977055.4, places=1
+            value(modObject.model.total_cost_objective_rule), 7977107.43, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
@@ -365,9 +365,9 @@ class TestGTEP(unittest.TestCase):
 
         modObject.results = opt.solve(modObject.model)
 
-        # previous successful objective values: 1524581869.89, 779334165.7
+        # previous successful objective values: 1524581869.89, 779334165.7, 779344643.1
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 779344643.1, places=1
+            value(modObject.model.total_cost_objective_rule), 779494030.29, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
@@ -413,9 +413,9 @@ class TestGTEP(unittest.TestCase):
 
         modObject.results = opt.solve(modObject.model)
 
-        # previous successful objective values: 1524533561.02
+        # previous successful objective values: 1524533561.02, 926187704.4
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 926187704.4, places=1
+            value(modObject.model.total_cost_objective_rule), 926190577.22, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)


### PR DESCRIPTION
Fixes #111
Fixes #115

We were missing the instantiation of `m.thermalReactiveCapacity`, used to bound `dispatchBlock.thermalReactiveGeneration` when using `"ACP"` or `"ACR"` flow model config options, preventing model build with these options enabled. There was also some unit inconsistencies in the `reactiveGeneratorCost` expression in `dispatch.py`, and `thermalGeneratorCost` was noticed to be missing a term for fuel costs. To resolve these:
- Added some code to pull the min/max allowed values for thermal reactive generation from the model data
- Defined `m.fuelCostReactive` with units of USD/MVAR/hr (same value as `m.fuelCost` but with MVAR instead of MW)
- Added the dispatch period duration in the expression for `reactiveGeneratorCost` so it correctly has units of USD
- Added a term with `m.fuelCosts` to `thermalGeneratorCost` in `dispatch.py`