### PR TITLE
Re-define parameter `m.weights` for the representative days

### DIFF
--- a/gtep/driver_esr.py
+++ b/gtep/driver_esr.py
@@ -30,7 +30,13 @@ data_object = ExpansionPlanningData(
     num_dispatch=4,
     duration_dispatch=15,
 )
-data_object.load_prescient(data_path)
+data_object.load_prescient(
+    data_path,
+    # representative_dates=[
+    #     '2020-01-28 00:00', '2020-04-23 00:00', '2020-07-05 00:00', '2020-10-14 00:00'
+    # ],
+    # representative_weights=[1, 1, 1, 1]
+)
 
 # [ESR WIP: Add bus and cost data files to be used on the
 # DataProcessing class. This class processes data for the following

--- a/gtep/gtep_data.py
+++ b/gtep/gtep_data.py
@@ -158,24 +158,17 @@ class ExpansionPlanningData:
                     "Not enough available day-start timestamps to select default representative dates. Please provide a custom list of representative_dates in the driver or reduce num_reps."
                 )
 
-            # Pick 4 default representative dates from the loaded data:
-            # winter, spring, summer, and fall. If self.num_reps < 4, use only
-            # the first self.num_reps default dates. If more than 4 representative
-            # periods are requested, keep these 4 defaults and randomly select the
-            # remaining dates from the available day-start timestamps.
+            # Pick 4 default representative dates from the loaded
+            # data: winter, spring, summer, and fall. If self.num_reps
+            # < 4, use only the first self.num_reps default dates. If
+            # more than 4 representative periods are requested, keep
+            # these 4 defaults and randomly select the remaining dates
+            # from the available day-start timestamps.
             default_representative_dates = [
-                available_day_starts[
-                    int(0.074 * len(available_day_starts))
-                ],  # 2020-01-28
-                available_day_starts[
-                    int(0.310 * len(available_day_starts))
-                ],  # 2020-04-23
-                available_day_starts[
-                    int(0.510 * len(available_day_starts))
-                ],  # 2020-07-05
-                available_day_starts[
-                    int(0.788 * len(available_day_starts))
-                ],  # 2020-10-14
+                available_day_starts[27],  # 2020-01-28
+                available_day_starts[113],  # 2020-04-23
+                available_day_starts[186],  # 2020-07-05
+                available_day_starts[287],  # 2020-10-14
             ]
 
             if self.num_reps <= 4:

--- a/gtep/gtep_data.py
+++ b/gtep/gtep_data.py
@@ -155,17 +155,54 @@ class ExpansionPlanningData:
             ]
         self.representative_dates = representative_dates
 
-        if not representative_weights:
-            # set the weight for each day to the total weight divided by number of days
-            total_weight = prescient_options.num_days * self.stages
-            weight_per_date = int(total_weight / (len(representative_dates)))
-            self.representative_weights = {
-                key: weight_per_date
-                for date, key in enumerate(self.representative_dates)
+        if representative_weights:
+
+            if len(representative_dates) != len(representative_weights):
+                raise ValueError(
+                    "Length of representative_dates and representative_weights must match."
+                )
+            else:
+                print(
+                    "INFO: representative_dates and representative_weights are aligned. Continue building the data modeling object..."
+                )
+
+            # Store as a list attribute
+            self.representative_weights = list(representative_weights)
+
+            # Additionally, create a mapping for later use:
+            self.representative_weights_dict = dict(
+                zip(representative_dates, representative_weights)
+            )
+
+        else:
+
+            # Set weight for each representative day to default value
+            # of 1. The other option is to set the weight for each day
+            # to the total weight divided by the number of
+            # representative dates.
+            set_default_weight = True
+            if set_default_weight:
+                weight_per_date = 1
+            else:
+                total_weight = prescient_options.num_days * self.stages
+                weight_per_date = int(total_weight / len(representative_dates))
+
+            # Store weights as a list, aligned with self.representative_dates
+            self.representative_weights = [
+                weight_per_date for _ in self.representative_dates
+            ]
+
+            # Store weights also as a dictionary by representative date
+            self.representative_weights_dict = {
+                date: weight_per_date for date in self.representative_dates
             }
 
+        # IMPORTANT TO READ: Always add or modify any new elements in
+        # self.md.data (such as new time series or parameters) BEFORE
+        # creating representative_data using clone_at_time_keys. This
+        # ensures all representative ModelData objects will have the
+        # new elements.
         time_keys = self.md.data["system"]["time_keys"]
-
         for date in self.representative_dates:
             key_idx = time_keys.index(date)
             time_key_set = time_keys[key_idx : key_idx + period_per_step]

--- a/gtep/gtep_data.py
+++ b/gtep/gtep_data.py
@@ -16,6 +16,7 @@
 # author: Kyle Skolfield
 # date: 01/04/2024
 # Model available at http://www.optimization-online.org/DB_FILE/2017/08/6162.pdf
+import random
 
 from pyomo.environ import *
 from prescient.simulator.config import PrescientConfig
@@ -142,17 +143,86 @@ class ExpansionPlanningData:
             if "-c" in stor:  # key/Branch UID
                 self.md.data["elements"]["storage"][stor]["in_service"] = False
 
-        ## NOTE: Below is only for multiple representative periods and creates a list
-        ## of modelData objects, not just a single modelData object
-        # Arbitrary time points and lengths picked for representative periods
-        # default here allows up to 24 hours for periods
+        # Get the timestamps in the loaded day-ahead data. Default
+        # representative_dates are selected from this list to ensure
+        # they correspond to valid input data timestamps. if
+        # representative_dates are provided by the user, those values
+        # are used instead.
+        time_keys = self.md.data["system"]["time_keys"]
+
         if representative_dates is None:
-            representative_dates = [
-                "2020-01-28 00:00",
-                "2020-04-23 00:00",
-                "2020-07-05 00:00",
-                "2020-10-14 00:00",  ## Change the last date for whatever extreme day is needed based on the given run(s)
+            available_day_starts = time_keys[::period_per_step]
+
+            if len(available_day_starts) < self.num_reps:
+                raise ValueError(
+                    "Not enough available day-start timestamps to select default representative dates. Please provide a custom list of representative_dates in the driver or reduce num_reps."
+                )
+
+            # Pick 4 default representative dates from the loaded data:
+            # winter, spring, summer, and fall. If self.num_reps < 4, use only
+            # the first self.num_reps default dates. If more than 4 representative
+            # periods are requested, keep these 4 defaults and randomly select the
+            # remaining dates from the available day-start timestamps.
+            default_representative_dates = [
+                available_day_starts[
+                    int(0.074 * len(available_day_starts))
+                ],  # 2020-01-28
+                available_day_starts[
+                    int(0.310 * len(available_day_starts))
+                ],  # 2020-04-23
+                available_day_starts[
+                    int(0.510 * len(available_day_starts))
+                ],  # 2020-07-05
+                available_day_starts[
+                    int(0.788 * len(available_day_starts))
+                ],  # 2020-10-14
             ]
+
+            if self.num_reps <= 4:
+                representative_dates = default_representative_dates[: self.num_reps]
+            else:
+                if len(available_day_starts) < self.num_reps:
+                    raise ValueError(
+                        "Not enough available day-start timestamps to select default representative dates. "
+                        "Please provide a custom list of representative_dates in the driver or reduce num_reps."
+                    )
+
+                random_seed = 42
+                rng = random.Random(random_seed)
+                remaining_dates = [
+                    date
+                    for date in available_day_starts
+                    if date not in default_representative_dates
+                ]
+                additional_dates = rng.sample(
+                    remaining_dates,
+                    self.num_reps - len(default_representative_dates),
+                )
+                representative_dates = sorted(
+                    default_representative_dates + additional_dates,
+                    key=lambda date: time_keys.index(date),
+                )
+        else:
+            # Validate that the user-provided representative_dates
+            # match the requested number of representative periods.
+            if len(representative_dates) != self.num_reps:
+                raise ValueError(
+                    f"The number of provided representative_dates must match num_reps. "
+                    f"Received len(representative_dates)={len(representative_dates)}, "
+                    f"but num_reps={self.num_reps}."
+                )
+
+            # Validate that all user-provided representative dates
+            # exist in the loaded day-ahead timestamps.
+            missing_dates = [
+                date for date in representative_dates if date not in time_keys
+            ]
+            if missing_dates:
+                raise ValueError(
+                    "The following representative_dates are not valid timestamps in the "
+                    f"loaded day-ahead input data: {missing_dates}"
+                )
+
         self.representative_dates = representative_dates
 
         if representative_weights:
@@ -166,10 +236,7 @@ class ExpansionPlanningData:
                     "INFO: representative_dates and representative_weights are aligned. Continue building the data modeling object..."
                 )
 
-            # Store as a list attribute
-            self.representative_weights = list(representative_weights)
-
-            # Additionally, create a mapping for later use:
+            # Store as a dictionary
             self.representative_weights_dict = dict(
                 zip(representative_dates, representative_weights)
             )
@@ -187,12 +254,7 @@ class ExpansionPlanningData:
                 total_weight = prescient_options.num_days * self.stages
                 weight_per_date = int(total_weight / len(representative_dates))
 
-            # Store weights as a list, aligned with self.representative_dates
-            self.representative_weights = [
-                weight_per_date for _ in self.representative_dates
-            ]
-
-            # Store weights also as a dictionary by representative date
+            # Store weights as a dictionary by representative date
             self.representative_weights_dict = {
                 date: weight_per_date for date in self.representative_dates
             }

--- a/gtep/model_library/components.py
+++ b/gtep/model_library/components.py
@@ -383,7 +383,16 @@ def add_model_parameters(m, num_commit, num_dispatch, duration_dispatch):
     m.peakLoad = pyo.Param(m.stages, default=0, units=u.MW)
     m.reserveMargin = pyo.Param(m.stages, default=0, units=u.MW)
     m.renewableQuota = pyo.Param(m.stages, default=0, units=u.MW)
-    m.weights = pyo.Param(m.representativePeriods, default=1)
+
+    weights_dict = {
+        i: w for i, w in zip(m.representativePeriods, m.data.representative_weights)
+    }
+    m.weights = pyo.Param(
+        m.representativePeriods,
+        initialize=weights_dict,
+        mutable=False,
+    )
+
     m.investmentFactor = pyo.Param(
         m.stages, default=1, mutable=True, units=u.dimensionless
     )

--- a/gtep/model_library/components.py
+++ b/gtep/model_library/components.py
@@ -34,6 +34,11 @@ def add_model_sets(m, stages, rep_per=["a", "b"], com_per=2, dis_per=2):
     # without being forced.]
     m.stages = pyo.RangeSet(stages, doc="Set of planning periods")
 
+    m.representativeDates = pyo.Set(
+        initialize=m.data.representative_dates,
+        doc="Set of representative dates used for each representative period",
+    )
+
     m.representativePeriods = pyo.Set(
         initialize=rep_per,
         doc="Set of representative periods for each planning period",
@@ -384,13 +389,29 @@ def add_model_parameters(m, num_commit, num_dispatch, duration_dispatch):
     m.reserveMargin = pyo.Param(m.stages, default=0, units=u.MW)
     m.renewableQuota = pyo.Param(m.stages, default=0, units=u.MW)
 
+    # Map each representative period to its corresponding date, then
+    # use that date to retrieve the appropriate representative
+    # weight. This keeps the model indexed by representative period
+    # number.
+    representative_dates_dict = {
+        i: date for i, date in zip(m.representativePeriods, m.data.representative_dates)
+    }
+    m.representativeDate = pyo.Param(
+        m.representativePeriods,
+        initialize=representative_dates_dict,
+        within=pyo.Any,
+        mutable=False,
+        doc="Representative date associated with each representative period",
+    )
     weights_dict = {
-        i: w for i, w in zip(m.representativePeriods, m.data.representative_weights)
+        i: m.data.representative_weights_dict[representative_dates_dict[i]]
+        for i in m.representativePeriods
     }
     m.weights = pyo.Param(
         m.representativePeriods,
         initialize=weights_dict,
         mutable=False,
+        doc="Representative period weights indexed by representative period",
     )
 
     m.investmentFactor = pyo.Param(

--- a/gtep/model_library/components.py
+++ b/gtep/model_library/components.py
@@ -34,11 +34,6 @@ def add_model_sets(m, stages, rep_per=["a", "b"], com_per=2, dis_per=2):
     # without being forced.]
     m.stages = pyo.RangeSet(stages, doc="Set of planning periods")
 
-    m.representativeDates = pyo.Set(
-        initialize=m.data.representative_dates,
-        doc="Set of representative dates used for each representative period",
-    )
-
     m.representativePeriods = pyo.Set(
         initialize=rep_per,
         doc="Set of representative periods for each planning period",

--- a/gtep/tests/unit/test_gtep_model.py
+++ b/gtep/tests/unit/test_gtep_model.py
@@ -283,7 +283,11 @@ class TestGTEP(unittest.TestCase):
     def test_solve_bigm(self):
         # Solve the debug model as is
         data_object = read_debug_model(
-            num_reps=1, len_reps=1, num_commit=1, num_dispatch=1
+            num_reps=1,
+            len_reps=1,
+            num_commit=1,
+            num_dispatch=1,
+            representative_dates=["2020-01-28 00:00"],
         )
         modObject = ExpansionPlanningModel(data=data_object)
         modObject.create_model()
@@ -303,7 +307,7 @@ class TestGTEP(unittest.TestCase):
 
         # previous successful objective values: 9207.95, 6078.86, 531860.15, 531883.43, 7977055.4, 7977055.4
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 7977151.99, places=1
+            value(modObject.model.total_cost_objective_rule), 7977150.30, places=1
         )
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
 
@@ -314,6 +318,7 @@ class TestGTEP(unittest.TestCase):
             len_reps=1,
             num_commit=1,
             num_dispatch=1,
+            representative_dates=["2020-01-28 00:00"],
         )
         modObject = ExpansionPlanningModel(
             data=data_object,
@@ -338,7 +343,7 @@ class TestGTEP(unittest.TestCase):
 
         # previous successful objective values: 531860.15, 531883.43, 7977055.4, 7977055.4
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 7977151.99, places=1
+            value(modObject.model.total_cost_objective_rule), 7977150.30, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
@@ -386,7 +391,7 @@ class TestGTEP(unittest.TestCase):
 
         # previous successful objective values: 1524581869.89, 779334165.7, 779344643.1
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 779486735.40, places=1
+            value(modObject.model.total_cost_objective_rule), 779486340.91, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
@@ -434,7 +439,7 @@ class TestGTEP(unittest.TestCase):
 
         # previous successful objective values: 1524533561.02, 926187704.4
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 926195251.45, places=1
+            value(modObject.model.total_cost_objective_rule), 926194856.96, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)

--- a/gtep/tests/unit/test_gtep_model.py
+++ b/gtep/tests/unit/test_gtep_model.py
@@ -503,5 +503,9 @@ class TestGTEP(unittest.TestCase):
 
         # Check that each representative period in the model is
         # assigned the expected representative weight
-        for rep_period, expected_weight in zip(modObject.model.representativePeriods, weights):
-            self.assertEqual(value(modObject.model.weights[rep_period]), expected_weight)
+        for rep_period, expected_weight in zip(
+            modObject.model.representativePeriods, weights
+        ):
+            self.assertEqual(
+                value(modObject.model.weights[rep_period]), expected_weight
+            )

--- a/gtep/tests/unit/test_gtep_model.py
+++ b/gtep/tests/unit/test_gtep_model.py
@@ -454,7 +454,7 @@ class TestGTEP(unittest.TestCase):
         # with HiGHS when using the full representative-day weights.
         # These values are intended only to verify that the model
         # reads and applies representative weights correctly.
-        weights = [10, 10]
+        weights = [10, 12]
         dataObject, dataProcessingObject = prepare_model_and_cost_data(
             stages=2,
             num_reps=2,
@@ -496,7 +496,12 @@ class TestGTEP(unittest.TestCase):
         modObject.results = opt.solve(modObject.model)
 
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 7794863409.17, places=1
+            value(modObject.model.total_cost_objective_rule), 8584301655.08, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
+
+        # Check that each representative period in the model is
+        # assigned the expected representative weight
+        for rep_period, expected_weight in zip(modObject.model.representativePeriods, weights):
+            self.assertEqual(value(modObject.model.weights[rep_period]), expected_weight)

--- a/gtep/tests/unit/test_gtep_model.py
+++ b/gtep/tests/unit/test_gtep_model.py
@@ -198,7 +198,7 @@ class TestGTEP(unittest.TestCase):
                 "duration_dispatch": 15,
             },
             prescient_data_args={
-                "representative_dates":["2020-01-28 00:00"],
+                "representative_dates": ["2020-01-28 00:00"],
             },
             include_cost_data=False,
         )
@@ -234,7 +234,7 @@ class TestGTEP(unittest.TestCase):
                 "duration_dispatch": 15,
             },
             prescient_data_args={
-                "representative_dates":["2020-01-28 00:00"],
+                "representative_dates": ["2020-01-28 00:00"],
             },
             config={
                 "include_investment": False,
@@ -381,8 +381,8 @@ class TestGTEP(unittest.TestCase):
                 "duration_dispatch": 15,
             },
             prescient_data_args={
-                "representative_dates":["2020-01-28 00:00", "2020-04-23 00:00"],
-                "representative_weights":weights
+                "representative_dates": ["2020-01-28 00:00", "2020-04-23 00:00"],
+                "representative_weights": weights,
             },
             config={
                 "include_investment": True,

--- a/gtep/tests/unit/test_gtep_model.py
+++ b/gtep/tests/unit/test_gtep_model.py
@@ -303,7 +303,7 @@ class TestGTEP(unittest.TestCase):
 
         # previous successful objective values: 9207.95, 6078.86, 531860.15, 531883.43, 7977055.4, 7977055.4
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 7977153.07, places=1
+            value(modObject.model.total_cost_objective_rule), 7977151.99, places=1
         )
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
 
@@ -338,7 +338,7 @@ class TestGTEP(unittest.TestCase):
 
         # previous successful objective values: 531860.15, 531883.43, 7977055.4, 7977055.4
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 7977153.07, places=1
+            value(modObject.model.total_cost_objective_rule), 7977151.99, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
@@ -491,7 +491,7 @@ class TestGTEP(unittest.TestCase):
         modObject.results = opt.solve(modObject.model)
 
         self.assertAlmostEqual(
-            value(modObject.model.total_cost_objective_rule), 7794940302.85, places=1
+            value(modObject.model.total_cost_objective_rule), 7794863409.17, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)

--- a/gtep/tests/unit/test_gtep_model.py
+++ b/gtep/tests/unit/test_gtep_model.py
@@ -54,6 +54,8 @@ def read_debug_model(
     num_commit=24,
     num_dispatch=4,
     duration_dispatch=15,
+    representative_dates=["2020-01-28 00:00", "2020-04-23 00:00"],
+    representative_weights=None,
 ):
     curr_dir = dirname(abspath(__file__))
     debug_data_path = abspath(join(curr_dir, "..", "..", "data", "5bus"))
@@ -65,7 +67,11 @@ def read_debug_model(
         num_dispatch=num_dispatch,
         duration_dispatch=duration_dispatch,
     )
-    dataObject.load_prescient(debug_data_path)
+    dataObject.load_prescient(
+        debug_data_path,
+        representative_dates,
+        representative_weights,
+    )
     return dataObject
 
 
@@ -76,6 +82,8 @@ def prepare_model_and_cost_data(
     num_commit=24,
     num_dispatch=4,
     duration_dispatch=15,
+    representative_dates=None,
+    representative_weights=None,
 ):
     # Prepare model and cost data
     dataObject = read_debug_model(
@@ -85,6 +93,8 @@ def prepare_model_and_cost_data(
         num_commit,
         num_dispatch,
         duration_dispatch,
+        representative_dates,
+        representative_weights,
     )
     curr_dir = dirname(abspath(__file__))
     data_path = abspath(join(curr_dir, "..", "..", "data", "costs"))
@@ -121,8 +131,11 @@ def prepare_model_and_cost_data(
 @pytest.mark.usefixtures("patch_unit_handlers")
 class TestGTEP(unittest.TestCase):
     def test_model_init(self):
-        # Test that the ExpansionPlanningModel object can read a default dataset and init
-        # properly with default values, including building a Pyomo.ConcreteModel object
+        # Test that the ExpansionPlanningModel object can read a
+        # default dataset and init properly with default values,
+        # including building a Pyomo.ConcreteModel object. Set
+        # representative_dates and weights to None to get default
+        # values from gtep_data model object.
         data_object = read_debug_model(
             stages=1,
             num_reps=3,
@@ -130,6 +143,8 @@ class TestGTEP(unittest.TestCase):
             num_commit=24,
             num_dispatch=4,
             duration_dispatch=60,
+            representative_dates=None,
+            representative_weights=None,
         )
         modObject = ExpansionPlanningModel(data=data_object)
         self.assertIsInstance(modObject, ExpansionPlanningModel)
@@ -144,8 +159,10 @@ class TestGTEP(unittest.TestCase):
         self.assertEqual(modObject.num_dispatch, 4)
         self.assertEqual(modObject.duration_dispatch, 60)
 
-        # Test that the ExpansionPlanningModel object can read a default dataset and init
-        # properly with non-default values
+        # Test that the ExpansionPlanningModel object can read a
+        # default dataset and init properly with non-default
+        # values. Set representative_dates and weights to None to get
+        # default values from gtep_data model object.
         data_object = read_debug_model(
             stages=2,
             num_reps=4,
@@ -153,6 +170,8 @@ class TestGTEP(unittest.TestCase):
             num_commit=12,
             num_dispatch=12,
             duration_dispatch=30,
+            representative_dates=None,
+            representative_weights=None,
         )
         modObject = ExpansionPlanningModel(
             data=data_object,
@@ -416,6 +435,63 @@ class TestGTEP(unittest.TestCase):
         # previous successful objective values: 1524533561.02, 926187704.4
         self.assertAlmostEqual(
             value(modObject.model.total_cost_objective_rule), 926190577.22, places=1
+        )
+
+        assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)
+
+    def test_with_cost_data_and_weights(self):
+
+        # Typically, representative weights should reflect how many
+        # actual days each representative day represents. For example,
+        # with 2 representative days in a 365-day year, the weights
+        # would be approximately [182, 183].  For now, we use
+        # simplified test values because the model becomes infeasible
+        # with HiGHS when using the full representative-day weights.
+        # These values are intended only to verify that the model
+        # reads and applies representative weights correctly.
+        weights = [10, 10]
+        dataObject, dataProcessingObject = prepare_model_and_cost_data(
+            stages=2,
+            num_reps=2,
+            len_reps=1,
+            num_commit=6,
+            num_dispatch=4,
+            duration_dispatch=15,
+            representative_dates=["2020-01-28 00:00", "2020-04-23 00:00"],
+            representative_weights=weights,
+        )
+
+        # Populate and create GTEP model
+        modObject = ExpansionPlanningModel(
+            data=dataObject,
+            cost_data=dataProcessingObject,
+        )
+
+        modObject.config["include_investment"] = True
+        modObject.config["include_commitment"] = True
+        modObject.config["include_redispatch"] = True
+        modObject.config["scale_loads"] = True
+        modObject.config["transmission"] = True
+        modObject.config["storage"] = False
+        modObject.config["flow_model"] = "DC"
+
+        modObject.create_model()
+
+        # Check for consistent units
+        # Note: Need to do this check before applying the GDP transformations
+        assert_units_consistent(modObject.model)
+
+        opt = SolverFactory("highs")
+        if not opt.available():
+            raise unittest.SkipTest("Solver not available")
+
+        # Apply transformations to logical terms
+        TransformationFactory("gdp.bigm").apply_to(modObject.model)
+
+        modObject.results = opt.solve(modObject.model)
+
+        self.assertAlmostEqual(
+            value(modObject.model.total_cost_objective_rule), 7794940302.85, places=1
         )
 
         assert_units_equivalent(modObject.model.total_cost_objective_rule.expr, u.USD)


### PR DESCRIPTION
This PR  re-defines the `m.weights` parameter to support two options: 
1. A set of default values provided in `gtep_data.py` (all weights for all representative days are set to 1, as in the original model), or
2. A list of weights provided by the user and added as an argument to the function `load_prescient()` from `gtep_data.py`. 