### PR TITLE
add .indicator_var where previously missing

### DIFF
--- a/gtep/model_library/gen.py
+++ b/gtep/model_library/gen.py
@@ -590,7 +590,7 @@ def add_generators_logical_constraints(m):
                 .indicator_var
                 | m.investmentStage[stage - pyo.value(m.lifetimes[gen])].genInstalled[
                     gen
-                ]
+                ].indicator_var
             ).implies(
                 m.investmentStage[stage].genRetired[gen].indicator_var
                 | m.investmentStage[stage].genExtended[gen].indicator_var

--- a/gtep/model_library/gen.py
+++ b/gtep/model_library/gen.py
@@ -588,9 +588,9 @@ def add_generators_logical_constraints(m):
                 m.investmentStage[stage - pyo.value(m.lifetimes[gen])]
                 .genOperational[gen]
                 .indicator_var
-                | m.investmentStage[stage - pyo.value(m.lifetimes[gen])].genInstalled[
-                    gen
-                ].indicator_var
+                | m.investmentStage[stage - pyo.value(m.lifetimes[gen])]
+                .genInstalled[gen]
+                .indicator_var
             ).implies(
                 m.investmentStage[stage].genRetired[gen].indicator_var
                 | m.investmentStage[stage].genExtended[gen].indicator_var


### PR DESCRIPTION
One-line change. Missed a `.indicator_var` in a `LogicalConstraint` rule (`thermalgen_retirement). I think the line only ran for gens past their lifetimes, so we didn't run into the issue with shorter time frame models